### PR TITLE
Add a way to change channels on the DS2482-800

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -241,6 +241,20 @@ void OneWire::wireResetSearch()
 
 }
 
+// Set the channel on the DS2482-800
+uint8_t OneWire::setChannel(uint8_t ch){
+  uint8_t w[] = {0xf0, 0xe1, 0xd2, 0xc3, 0xb4, 0xa5, 0x96, 0x87};
+  uint8_t r[] = {0xb8, 0xb1, 0xaa, 0xa3, 0x9c, 0x95, 0x8e, 0x87};
+  waitOnBusy();
+  begin();
+  writeByte(0xc3);
+  writeByte(w[ch]);
+  end();
+  waitOnBusy();
+  return readByte() == r[ch];
+}
+
+
 // Perform a search of the 1-Wire bus
 uint8_t OneWire::wireSearch(uint8_t *address)
 {

--- a/OneWire.h
+++ b/OneWire.h
@@ -1,7 +1,9 @@
 #ifndef __ONEWIRE_H__
 #define __ONEWIRE_H__
 
+#include <stddef.h>
 #include <inttypes.h>
+
 
 // Chose between a table based CRC (flash expensive, fast)
 // or a computed CRC (smaller, slow)
@@ -59,6 +61,7 @@ public:
 	uint8_t readConfig();
 	void writeConfig(uint8_t config);
 	void setStrongPullup();
+    uint8_t setChannel(uint8_t ch);
 	void clearStrongPullup();
 	uint8_t wireReset();
 	void wireWriteByte(uint8_t data, uint8_t power = 0);


### PR DESCRIPTION
I am using the DS2482-800 and could not see a way to switch channels in your code. 
I borrowed the byte patterns from the paeae repo, but coded it rather more compactly. 
The #include stddef.h seemed to be required to compile on ESP32. (includes the size_t definition)  