### PR TITLE
Optional non-default SCL and SDA pin numbers for Wire

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -20,6 +20,28 @@ OneWire::OneWire(uint8_t address)
 	Wire.begin();
 }
 
+OneWire::OneWire(uint8_t sdaPin, uint8_t sclPin)
+{
+	// sdaPin and sclPin can override the default SCL and SDA
+	// pins on some hardware
+	// Address is determined by two pins on the DS2482 AD1/AD0
+	// Pass 0b00, 0b01, 0b10 or 0b11
+	mAddress = 0x18;
+	mError = 0;
+	Wire.begin(sdaPin, sclPin);
+}
+
+OneWire::OneWire(uint8_t sdaPin, uint8_t sclPin, uint8_t address)
+{
+	// sdaPin and sclPin can override the default SCL and SDA
+	// pins on some hardware
+	// Address is determined by two pins on the DS2482 AD1/AD0
+	// Pass 0b00, 0b01, 0b10 or 0b11
+	mAddress = 0x18 | address;
+	mError = 0;
+	Wire.begin(sdaPin, sclPin);
+}
+
 uint8_t OneWire::getAddress()
 {
 	return mAddress;

--- a/OneWire.h
+++ b/OneWire.h
@@ -48,6 +48,8 @@ class OneWire
 public:
 	OneWire();
 	OneWire(uint8_t address);
+	OneWire(uint8_t sdaPin, uint8_t sclPin);
+	OneWire(uint8_t sdaPin, uint8_t sclPin, uint8_t address);
 
 	uint8_t getAddress();
 	uint8_t getError();


### PR DESCRIPTION
Add the ability to call OneWire with non-default I2C SCL and SDA
pin numbers, which get passed to Wire.

Example for M5Stack M5StickC Plus with non-default I2C Pins:

 - `OneWire oneWire(26, 25);`

Example for M5Stack M5StickC Plus with non-default I2C Pins
and non-zero I2C Address

 - `OneWire oneWire(26, 25, 0b11);`